### PR TITLE
fix: remove colon from Japanese YAML content to fix parsing error

### DIFF
--- a/src/content/note/ja/containerd-tls-troubleshooting.md
+++ b/src/content/note/ja/containerd-tls-troubleshooting.md
@@ -6,7 +6,7 @@ description: containerd イメージプル時の TLS 証明書検証エラーの
 toc: true
 ---
 
-`tls: failed to verify certificate: x509` エラーは通常、以下の原因で発生します:
+`tls: failed to verify certificate: x509` エラーは通常、以下の原因で発生します
 - イメージレジストリが自己署名証明書または非 HTTPS 接続を使用している
 - containerd はデフォルトで TLS 検証を強制しており、信頼の設定がない
 


### PR DESCRIPTION
The colon at the end of the sentence was causing YAML parsing error in the Japanese containerd TLS troubleshooting guide.

<!--
  !!IMPORTANT!!
  Before submitting a Pull Request, please make sure to read and follow the guidelines in CONTRIBUTING.md.
  https://github.com/tuyuritio/astro-theme-thought-lite/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe what this PR does and why the change is needed. -->
<!-- Link any relevant issues if necessary, e.g., "Closes #1". -->
<!-- Be short and concise. Bullet points can help! -->
<!-- Before/after screenshots can help as well. -->

## Testing

<!-- How was this change tested? -->

## Docs

<!-- Could this affect a user’s behavior? Docs probably need an update! -->
