### PR TITLE
fix: replace ZeoSeven fonts with Google Fonts

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -33,7 +33,6 @@ import copy from "@tuyuritio/shiki-code-copy";
 import reading from "./src/utils/reading";
 
 import siteConfig from "./site.config";
-import ZeoSevenFonts from "./src/fonts/zeo-seven-fonts";
 
 // https://astro.build/config
 export default defineConfig({
@@ -143,10 +142,12 @@ export default defineConfig({
 				cssVariable: "--font-playwrite-mx"
 			},
 			{
-				name: "Maple Mono NF CN",
-				provider: ZeoSevenFonts(),
+				name: "JetBrains Mono",
+				provider: fontProviders.google(),
+				weights: [400, 700],
 				optimizedFallbacks: false,
 				fallbacks: [
+					"JetBrains Mono",
 					"Maple Mono NF CN",
 					"Maple Mono NF",
 					"Maple Mono CN",
@@ -160,10 +161,11 @@ export default defineConfig({
 				cssVariable: "--font-maple-mono-nf-cn"
 			},
 			{
-				name: "The Peak Font Plus",
-				provider: ZeoSevenFonts(),
+				name: "Noto Serif",
+				provider: fontProviders.google(),
+				weights: [400, 700],
 				optimizedFallbacks: false,
-				fallbacks: ["Georgia", "STSong", "serif"],
+				fallbacks: ["Noto Serif", "The Peak Font Plus", "Georgia", "STSong", "serif"],
 				cssVariable: "--font-the-peak-font-plus"
 			}
 		]


### PR DESCRIPTION
## Summary
- Replace ZeoSeven custom font CDN with Google Fonts due to accessibility issues
- Maple Mono NF CN → JetBrains Mono
- The Peak Font Plus → Noto Serif

## Test plan
- [ ] Verify build passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)